### PR TITLE
fix: request the install of riscv homebrew repo

### DIFF
--- a/Labs/Lab2/install-xv6-riscv.md
+++ b/Labs/Lab2/install-xv6-riscv.md
@@ -54,8 +54,14 @@ To install and run xv6-riscv on macOS, you can use Homebrew to install the neces
 ```
 Follow the on-screen instructions to complete the installation.
 
-2. Install the necessary dependencies: Run the following command in the terminal to install the required packages using Homebrew:
+2. Install the Homebrew repository for RISC-V toolchain maintained by RISC-V.
+```bash
+brew tap riscv-software-src/riscv
+```
+
+3. Install the necessary dependencies: Run the following command in the terminal to install the required packages using Homebrew:
 ```bash
 brew install riscv-gnu-toolchain qemu
 ```
-3. Follow the steps outlined in the "How to install and run xv6-riscv on Ubuntu" section above to clone the xv6-riscv repository, build xv6-riscv, and run it on macOS.
+
+4. Follow the steps outlined in the "How to install and run xv6-riscv on Ubuntu" section above to clone the xv6-riscv repository, build xv6-riscv, and run it on macOS.


### PR DESCRIPTION
A freshly installed Homebrew doesn't know the package riscv-gnu-toolchain because it's not in the official Homebrew repository. For Homebrew to find and install it, the user must first "tap" the formula repository of RISC-V tools maintained by RISC-V.